### PR TITLE
add fullscreenmonitor.patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ apply-patches:
 	$(PATCH) < patches/serverbotbalanceearly.patch
 	$(PATCH) < patches/bans.patch
 	$(PATCH) < patches/enet_mtu_1300.patch
+	$(PATCH) < patches/fullscreenmonitor.patch
 	cd src && make depend
 
 gzip-cfgs embed-cfgs: DATA=data/p1xbraten

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository contains the source for my client mod, as well as the patches ap
   - [anticheat.patch](#anticheatpatch)
   - [setfont.patch](#setfontpatch)
   - [filterservers.patch](#filterserverspatch)
+  - [fullscreenmonitor.patch](#fullscreenmonitorpatch)
 - [Server Patches](#server-patches)
   - [authservers.patch](#authserverspatch)
   - [serverlogging.patch](#serverloggingpatch)
@@ -346,7 +347,11 @@ Integrates Epic's Online Services SDK and Anti-Cheat framework to provide protec
 
 ### [filterservers.patch](./patches/filterservers.patch)
 
+### [fullscreenmonitor.patch](./patches/fullscreenmonitor.patch)
 
+- adds the `fullscreenmonitor` variable: specifies on which display the game runs on when in fullscreen mode, 0 being the primary display
+- adds the `getnummonitors` command: returns the number of connected displays
+- adds the `getmonitorname <id>` command: returns the name of the monitor with the specified index
 
 ## Server Patches
 

--- a/patches/fullscreenmonitor.patch
+++ b/patches/fullscreenmonitor.patch
@@ -1,0 +1,88 @@
+diff --git src/engine/main.cpp src/engine/main.cpp
+index 1270a20..90fd00c 100644
+--- src/engine/main.cpp
++++ src/engine/main.cpp
+@@ -113,9 +113,10 @@ void writeinitcfg()
+     stream *f = openutf8file("init.cfg", "w");
+     if(!f) return;
+     f->printf("// automatically written on exit, DO NOT MODIFY\n// modify settings in game\n");
+-    extern int fullscreen, fullscreendesktop;
++    extern int fullscreen, fullscreendesktop, fullscreenmonitor;
+     f->printf("fullscreen %d\n", fullscreen);
+     f->printf("fullscreendesktop %d\n", fullscreendesktop);
++    f->printf("fullscreenmonitor %d\n", fullscreenmonitor);
+     f->printf("scr_w %d\n", scr_w);
+     f->printf("scr_h %d\n", scr_h);
+     f->printf("depthbits %d\n", depthbits);
+@@ -561,6 +562,46 @@ void resetfullscreen()
+ 
+ VARF(fullscreendesktop, 0, 0, 1, if(fullscreen) resetfullscreen());
+ 
++void resetgl();
++void setfullscreenmonitor(int);
++VARF(fullscreenmonitor, 0, 0, 10, setfullscreenmonitor(fullscreenmonitor));
++
++void setfullscreenmonitor(int monitor)
++{
++    if (screen)
++    {
++        int currentmonitor = SDL_GetWindowDisplayIndex(screen);
++
++        if (fullscreenmonitor > SDL_GetNumVideoDisplays())
++        {
++            fullscreenmonitor = currentmonitor;
++            return;
++        }
++
++        if (fullscreen && monitor != currentmonitor)
++        {
++            resetgl();
++        }
++    }
++}
++
++int getnummonitors() 
++{
++    int n = SDL_GetNumVideoDisplays();
++    return n;
++}
++
++ICOMMAND(getnummonitors, "", (), intret(getnummonitors()));
++
++void getmonitorname(int *id)
++{
++    const char* name = SDL_GetDisplayName(*id);
++    if (name == NULL) name = "";
++    result(name);
++}
++
++COMMAND(getmonitorname, "i");
++
+ void screenres(int w, int h)
+ {               
+     scr_w = clamp(w, SCR_MINW, SCR_MAXW);
+@@ -645,7 +686,7 @@ void setupscreen()
+     curvsync = -1;
+ 
+     SDL_Rect desktop;
+-    if(SDL_GetDisplayBounds(0, &desktop) < 0) fatal("failed querying desktop bounds: %s", SDL_GetError());
++    if(SDL_GetDisplayBounds(fullscreenmonitor, &desktop) < 0) fatal("failed querying desktop bounds: %s", SDL_GetError());
+     desktopw = desktop.w;
+     desktoph = desktop.h;
+ 
+@@ -662,6 +703,8 @@ void setupscreen()
+     int winx = SDL_WINDOWPOS_UNDEFINED, winy = SDL_WINDOWPOS_UNDEFINED, winw = scr_w, winh = scr_h, flags = SDL_WINDOW_RESIZABLE;
+     if(fullscreen)
+     {
++        winx = desktop.x;
++        winy = desktop.y;
+         if(fullscreendesktop)
+         {
+             winw = desktopw;
+@@ -1446,4 +1489,4 @@ int main(int argc, char **argv)
+     #if defined(WIN32) && !defined(_DEBUG) && !defined(__GNUC__)
+     } __except(stackdumper(0, GetExceptionInformation()), EXCEPTION_CONTINUE_SEARCH) { return 0; }
+     #endif
+-}
++}
+\ No newline at end of file


### PR DESCRIPTION
Adds the `fullscreenmonitor` variable used to specify on which display the game runs on when in fullscreen mode.

I also added the `getnummonitors` and `getmonitorname` commands, with the intention of adding this setting to the options UI.
However on my windows 11 system, `SDL_GetDisplayName` returns "Generic PnP Monitor" for both my displays, making this kind
of pointless so I didn't make the UI (yet?)